### PR TITLE
add whenever --roles flag to hide leader-only schedules from non-leaders

### DIFF
--- a/bin/setup_cron
+++ b/bin/setup_cron
@@ -22,5 +22,5 @@ ec2 = AWS::EC2.new
 if ec2.instances[instance_id].tags["leader"] == "true"
 	`bundle exec whenever --roles leader --set 'environment=#{environment}&path=/var/app/current' --update-crontab`
 else
-	`bundle exec whenever --set 'environment=#{environment}&path=/var/app/current' --update-crontab`
+	`bundle exec whenever --roles non-leader --set 'environment=#{environment}&path=/var/app/current' --update-crontab`
 end


### PR DESCRIPTION
Without the presence of a '--roles' flag on the second Whenever command, Whenever was generating the same crontab for both instances.
This was causing schedules, tagged with the leader role, to be executed on non-leader elastic beanstalk nodes.

Thanks for your great work, @dignoe
