### PR TITLE
Parse config file with ERB

### DIFF
--- a/bin/create_cron_leader
+++ b/bin/create_cron_leader
@@ -4,6 +4,7 @@ require 'optparse'
 require 'rubygems'
 gem 'aws-sdk'
 require 'aws-sdk'
+require 'erb'
 
 options = {}
 
@@ -27,7 +28,7 @@ end
 optparse.parse!
 
 ENVIRONMENT_NAME_FILE = "/var/app/support/env_name"
-AWS_CREDENTIALS = YAML.load_file("config/whenever-elasticbeanstalk.yml")[ENV["RAILS_ENV"]]
+AWS_CREDENTIALS = YAML.load(ERB.new(File.read("config/whenever-elasticbeanstalk.yml")).result)[ENV["RAILS_ENV"]]
 
 instance_id = if File.exists?("/var/app/support/instance_id")
 	File.read("/var/app/support/instance_id")

--- a/bin/ensure_one_cron_leader
+++ b/bin/ensure_one_cron_leader
@@ -3,9 +3,10 @@
 require 'rubygems'
 gem 'aws-sdk'
 require 'aws-sdk'
+require 'erb'
 
 ENVIRONMENT_NAME_FILE = "/var/app/support/env_name"
-AWS_CREDENTIALS = YAML.load_file("config/whenever-elasticbeanstalk.yml")[ENV["RAILS_ENV"]]
+AWS_CREDENTIALS = YAML.load(ERB.new(File.read("config/whenever-elasticbeanstalk.yml")).result)[ENV["RAILS_ENV"]]
 
 instance_id = if File.exists?("/var/app/support/instance_id")
 	File.read("/var/app/support/instance_id")

--- a/bin/remove_cron_leader
+++ b/bin/remove_cron_leader
@@ -3,9 +3,10 @@ require 'rubygems'
 gem 'aws-sdk'
 
 require 'aws-sdk'
+require 'erb'
 
 ENVIRONMENT_NAME_FILE = "/var/app/support/env_name"
-AWS_CREDENTIALS = YAML.load_file("config/whenever-elasticbeanstalk.yml")[ENV["RAILS_ENV"]]
+AWS_CREDENTIALS = YAML.load(ERB.new(File.read("config/whenever-elasticbeanstalk.yml")).result)[ENV["RAILS_ENV"]]
 
 instance_id = if File.exists?("/var/app/support/instance_id")
 	File.read("/var/app/support/instance_id")

--- a/bin/setup_cron
+++ b/bin/setup_cron
@@ -3,9 +3,10 @@ require 'rubygems'
 gem 'aws-sdk'
 
 require 'aws-sdk'
+require 'erb'
 
 environment = ENV["RAILS_ENV"]
-AWS_CREDENTIALS = YAML.load_file("config/whenever-elasticbeanstalk.yml")[environment]
+AWS_CREDENTIALS = YAML.load(ERB.new(File.read("config/whenever-elasticbeanstalk.yml")).result)[ENV["RAILS_ENV"]]
 
 instance_id = if File.exists?("/var/app/support/instance_id")
   File.read("/var/app/support/instance_id")


### PR DESCRIPTION
Use case: credentials stored in env vars can be included in the config file with ERB.

``` yaml
# config/whenever-elasticbeanstalk.yml

staging:
  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
  secret_access_key: <%= ENV['AWS_SECRET_KEY'] %>
  region: 'eu-west-1'
production:
  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
  secret_access_key: <%= ENV['AWS_SECRET_KEY'] %>
  region: 'eu-west-1'
```
