### PR TITLE
Pull Request 20 Rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ end
 To run a task on all instance, omit the `roles` option.
 ```ruby
 every 1.minute do
-	command "touch /opt/elasticbeanstalk/containerfiles/.cron_check"
+	command "touch /opt/elasticbeanstalk/$EB_SUPPORT_FOLDER/.cron_check"
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ end
 To run a task on all instance, omit the `roles` option.
 ```ruby
 every 1.minute do
-	command "touch /opt/elasticbeanstalk/$EB_SUPPORT_FOLDER/.cron_check"
+	command "touch $EB_CONFIG_APP_SUPPORT/.cron_check"
 end
 ```
 

--- a/bin/wheneverize-eb
+++ b/bin/wheneverize-eb
@@ -80,7 +80,7 @@ files:
     group: root
     content: |
       #!/usr/bin/env bash
-      . /opt/elasticbeanstalk/containerfiles/envvars
+      . /opt/elasticbeanstalk/$EB_SUPPORT_FOLDER/envvars
       su -l -c "cd $EB_CONFIG_APP_CURRENT && /usr/local/bin/bundle exec setup_cron" $EB_CONFIG_APP_USER
   # Add Bundle to the PATH
   "/etc/profile.d/bundle.sh":
@@ -95,14 +95,17 @@ commands:
   create_bundle_symlink_patch:
     command: ln -s `su -l -c "which bundle" $EB_CONFIG_APP_USER` /usr/local/bin/bundle
     ignoreErrors: true
+  create_support_path_environment_variable:
+    command: export EB_SUPPORT_FOLDER=`echo "/var/app/support" | sed -r 's/^\/var\/app\/([a-z]+)$/\1/'`
+    ignoreErrors: false
 container_commands:
   cron_01_set_leader:
-    test: test ! -f /opt/elasticbeanstalk/containerfiles/.cron-setup-complete
+    test: test ! -f /opt/elasticbeanstalk/$EB_SUPPORT_FOLDER/.cron-setup-complete
     leader_only: true
     cwd: /var/app/ondeck
     command: su -c "/usr/local/bin/bundle exec create_cron_leader --no-update" $EB_CONFIG_APP_USER
   cron_02_write_cron_setup_complete_file:
-    cwd: /opt/elasticbeanstalk/containerfiles
+    cwd: /opt/elasticbeanstalk/$EB_SUPPORT_FOLDER
     command: touch .cron-setup-complete
 FILE
 

--- a/bin/wheneverize-eb
+++ b/bin/wheneverize-eb
@@ -80,7 +80,14 @@ files:
     group: root
     content: |
       #!/usr/bin/env bash
-      . /opt/elasticbeanstalk/$EB_SUPPORT_FOLDER/envvars
+      # /opt/elasticbeanstalk/hooks/appdeploy/post/10_reload_cron.sh
+
+      if test -d /opt/elasticbeanstalk/containerfiles; then
+        . /opt/elasticbeanstalk/containerfiles/envvars
+      elif test -d /opt/elasticbeanstalk/support; then
+        . /opt/elasticbeanstalk/support/envvars
+      fi
+      
       su -l -c "cd $EB_CONFIG_APP_CURRENT && /usr/local/bin/bundle exec setup_cron" $EB_CONFIG_APP_USER
   # Add Bundle to the PATH
   "/etc/profile.d/bundle.sh":
@@ -91,22 +98,55 @@ files:
       #!/usr/bin/env bash
       export PATH=$PATH:/usr/local/bin
     encoding: plain
+  # Update /opt/elasticbeanstalk/###/envvars.d/appenv to include EB_CONFIG_SUPPORT
+  /tmp/update_appenv_include_eb_config_support.sh:
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      # update_appenv_include_eb_config_support.sh
+      if test -d /opt/elasticbeanstalk/containerfiles; then
+        echo "containerfiles"
+        grep -Fwq "export EB_CONFIG_SUPPORT" /opt/elasticbeanstalk/containerfiles/envvars.d/appenv
+        if [ $? -eq 1 ]; then
+          echo "export EB_CONFIG_SUPPORT=/opt/elasticbeanstalk/support"
+          echo "export EB_CONFIG_SUPPORT=/opt/elasticbeanstalk/support" >> /opt/elasticbeanstalk/support/envvars.d/appenv;
+        fi
+      elif test -d /opt/elasticbeanstalk/support; then
+        echo "support"
+        grep -Fwq "export EB_CONFIG_SUPPORT" /opt/elasticbeanstalk/support/envvars.d/appenv
+        if [ $? -eq 1 ]; then
+          echo "export EB_CONFIG_SUPPORT=/opt/elasticbeanstalk/support"
+          echo "export EB_CONFIG_SUPPORT=/opt/elasticbeanstalk/support" >> /opt/elasticbeanstalk/support/envvars.d/appenv;
+        fi
+      fi
+    encoding: plain
 commands:
   create_bundle_symlink_patch:
+    test: test ! -f /usr/local/bin/bundle
     command: ln -s `su -l -c "which bundle" $EB_CONFIG_APP_USER` /usr/local/bin/bundle
     ignoreErrors: true
-  create_support_path_environment_variable:
-    command: export EB_SUPPORT_FOLDER=`echo "/var/app/support" | sed -r 's/^\/var\/app\/([a-z]+)$/\1/'`
+  a_elasticbeanstalk_support_path:
+    command: . /tmp/update_appenv_include_eb_config_support.sh
     ignoreErrors: false
+  zz_check_support_path_environment_variable:
+    command: echo $EB_SUPPORT
+    ignoreErrors: true
 container_commands:
   cron_01_set_leader:
-    test: test ! -f /opt/elasticbeanstalk/$EB_SUPPORT_FOLDER/.cron-setup-complete
+    test: test ! -f /opt/elasticbeanstalk/containerfiles/.cron-setup-complete || test ! -f /opt/elasticbeanstalk/support/.cron-setup-complete
     leader_only: true
     cwd: /var/app/ondeck
     command: su -c "/usr/local/bin/bundle exec create_cron_leader --no-update" $EB_CONFIG_APP_USER
-  cron_02_write_cron_setup_complete_file:
-    cwd: /opt/elasticbeanstalk/$EB_SUPPORT_FOLDER
-    command: touch .cron-setup-complete
+  cron_02_write_cron_setup_complete_file_containerfiles:
+    test: test -d /opt/elasticbeanstalk/containerfiles
+    command: touch /opt/elasticbeanstalk/containerfiles/.cron-setup-complete
+    ignoreErrors: true
+  cron_02_write_cron_setup_complete_file_support:
+    test: test -d /opt/elasticbeanstalk/support
+    command: touch /opt/elasticbeanstalk/support/.cron-setup-complete
+    ignoreErrors: true
 FILE
 
 file = '.ebextensions/cron.config'

--- a/bin/wheneverize-eb
+++ b/bin/wheneverize-eb
@@ -81,8 +81,7 @@ files:
     content: |
       #!/usr/bin/env bash
       . /opt/elasticbeanstalk/containerfiles/envvars
-      cd $EB_CONFIG_APP_CURRENT
-      su -c "/usr/local/bin/bundle exec setup_cron" $EB_CONFIG_APP_USER
+      su -l -c "cd $EB_CONFIG_APP_CURRENT && /usr/local/bin/bundle exec setup_cron" $EB_CONFIG_APP_USER
   # Add Bundle to the PATH
   "/etc/profile.d/bundle.sh":
     mode: "000755"
@@ -92,6 +91,10 @@ files:
       #!/usr/bin/env bash
       export PATH=$PATH:/usr/local/bin
     encoding: plain
+commands:
+  create_bundle_symlink_patch:
+    command: ln -s `su -l -c "which bundle" $EB_CONFIG_APP_USER` /usr/local/bin/bundle
+    ignoreErrors: true
 container_commands:
   cron_01_set_leader:
     test: test ! -f /opt/elasticbeanstalk/containerfiles/.cron-setup-complete

--- a/lib/whenever-elasticbeanstalk/version.rb
+++ b/lib/whenever-elasticbeanstalk/version.rb
@@ -1,5 +1,5 @@
 module Whenever
   module Elasticbeanstalk
-    VERSION = "1.1.4"
+    VERSION = "1.1.5"
   end
 end

--- a/whenever-elasticbeanstalk.gemspec
+++ b/whenever-elasticbeanstalk.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |gem|
   gem.name          = "whenever-elasticbeanstalk"
   gem.version       = Whenever::Elasticbeanstalk::VERSION
   gem.platform      = Gem::Platform::RUBY
-  gem.authors       = ["Chad McGimpsey","Joel Courtney"]
-  gem.email         = ["chad.mcgimpsey@gmail.com","euphemize@gmail.com"]
+  gem.authors       = ["Chad McGimpsey","Joel Courtney","Taylor Boyko"]
+  gem.email         = ["chad.mcgimpsey@gmail.com","euphemize@gmail.com","taylorboyko@gmail.com"]
   gem.description   = %q{Use Whenever on AWS Elastic Beanstalk}
   gem.summary       = %q{Allows you to run cron jobs easily on one or all AWS Elastic Beanstalk instances.}
   gem.homepage      = "https://github.com/dignoe/whenever-elasticbeanstalk"


### PR DESCRIPTION
@tboyko has provided a pull request ( https://github.com/dignoe/whenever-elasticbeanstalk/pull/20 ) which resolves some issues however was incomplete.

This pull request needed to deal with AWS inadequate identification of the path to the support/containerfiles in the /opt/elasticbeanstalk/ path. I have raised this with AWS Support Forum ( https://forums.aws.amazon.com/thread.jspa?messageID=581694&#581694 ) but have yet to see any activity.

This _should_ work with environments using _either_ /support or /containerfiles.
